### PR TITLE
addMapInitializedListener spelling and double-click trigger

### DIFF
--- a/GMapsFX/src/main/java/com/lynden/gmapsfx/GoogleMapView.java
+++ b/GMapsFX/src/main/java/com/lynden/gmapsfx/GoogleMapView.java
@@ -349,7 +349,7 @@ public class GoogleMapView extends AnchorPane {
         return direc;
     }
 
-    public void addMapInializedListener(MapComponentInitializedListener listener) {
+    public void addMapInitializedListener(MapComponentInitializedListener listener) {
         synchronized (mapInitializedListeners) {
             mapInitializedListeners.add(listener);
         }
@@ -462,7 +462,7 @@ public class GoogleMapView extends AnchorPane {
 
             if (event instanceof MouseEvent) {
                 MouseEvent mouseEvent = (MouseEvent) event;
-                if (mouseEvent.getClickCount() == 2) {
+                if (mouseEvent.getClickCount() > 1) {
                     if (disableDoubleClick) {
                         mouseEvent.consume();
                     }


### PR DESCRIPTION
Fix spelling of addMapInitializedListener closing #141, change double-click event trigger to > 1 to fix #136