### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,37 @@
-##  GMapsFX
+#  GMapsFX
 
 [ ![Download](https://api.bintray.com/packages/dlsc-oss/repository/GMapsFX/images/download.svg) ](https://bintray.com/dlsc-oss/repository/GMapsFX/_latestVersion)
 
 A pure JavaFX API which allows you to add Google Maps to your JavaFX application without the need to interact with the underlying Google Maps JavaScript API.
 
-GMapsFX requires Java 8
-
-
+GMapsFX requires Java 11 and JavaFX 17.
 
 ![GMapsFX GUI](http://rterp.files.wordpress.com/2014/05/gmapsfx.png)
 
-
-
 ## Quick Start
 
-##### Build the framework
+### Build the framework
 
 ```bash
-$ mvn install
+cd GMapsFX
+./mvnw install
 ```
 
-##### Run the sample application
+### Run the sample application
+
 ```bash
-$ mvn exec:java
+./mvnw exec:java
 ```
 
+## Development Notes
 
-##### Development Notes
-The GMapsFX framework creates underyling JavaScript peer objects when their corresponding Java objects are instantiated.  For example when a new com.lynden.gmapsfx.javascript.object.LatLong object is created, the object's constructor will also create a corresponding LatLong object in the JavaScript environment.
+The GMapsFX framework creates underyling JavaScript peer objects when their corresponding Java objects are instantiated.  For example when a new `com.dlsc.gmapsfx.javascript.object.LatLong` object is created, the object's constructor will also create a corresponding `LatLong` object in the JavaScript environment.
 
-Because of this it is important to note that you cannot instantiate JavaScript objects until the JavaScript engine has been fully initialized.  The JavaScript engine is intialized asynchronously when a new GoogleMapView component is created.  You can register a MapComponentInitializedListener to be notified when the map and JavaScript environment has been fully initialized.  
+This means that you cannot instantiate JavaScript objects until the JavaScript engine has been fully initialized.  The JavaScript engine is intialized asynchronously when a new GoogleMapView component is created.  You can register a MapComponentInitializedListener to be notified when the map and JavaScript environment has been fully initialized.  
 
-You can take a look at a small example code snippet [here.]( http://dlsc-software-consulting-gmbh.github.io/GMapsFX/)
+You can take a look at a small example code snippet [here.](https://dlsc-software-consulting-gmbh.github.io/GMapsFX/)
 
-The latest Javadocs can be found [here.] (http://dlsc-software-consulting-gmbh.github.io/GMapsFX/apidocs/)
-
+The latest Javadocs can be found [here.](https://dlsc-software-consulting-gmbh.github.io/GMapsFX/apidocs/)
 
 ## Authors
 
@@ -45,7 +42,7 @@ The latest Javadocs can be found [here.] (http://dlsc-software-consulting-gmbh.g
 ## License
 
 Apache License, Version 2.0 (current)
-http://www.apache.org/licenses/LICENSE-2.0
+<http://www.apache.org/licenses/LICENSE-2.0>
 
 Also, please be aware, in order to use this library, you must also accept the Google Terms of Service.
-https://developers.google.com/maps/faq#understanding-terms-of-service
+<https://developers.google.com/maps/faq#understanding-terms-of-service>


### PR DESCRIPTION
Main goal was `mvn` -> `./mvnw` since the version of maven required is too recent for most distribution versions.

Also fixed some links to use https and markdown formatting.

The bintray link at the top is broken - don't know if that is still being used, or its just on maven central. The screenshot link could be updated to use a local file, but that seemed less important.
