### PR TITLE
docs: fix javadoc warning

### DIFF
--- a/GMapsFX/src/main/java/com/dlsc/gmapsfx/javascript/object/MarkerClusterer.java
+++ b/GMapsFX/src/main/java/com/dlsc/gmapsfx/javascript/object/MarkerClusterer.java
@@ -69,7 +69,6 @@ public class MarkerClusterer extends JavascriptObject {
      * Sets the max zoom for the clusterer.
      *
      * @param number
-     * @return
      */
     public void setMaxZoom(int number) {
         invokeJavascript("setMaxZoom", number);
@@ -92,7 +91,6 @@ public class MarkerClusterer extends JavascriptObject {
      * Sets the max zoom for the clusterer.
      *
      * @param number
-     * @return
      */
     public void setGridSize(int number) {
         invokeJavascript("setGridSize", number);


### PR DESCRIPTION
Fixes compile-time warning (`@return tag cannot be used in method with void return type.`)